### PR TITLE
add support for more recent versions of the autoscaler

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -10,7 +10,8 @@ data "aws_iam_policy_document" "kubernetes_cluster_autoscaler" {
       "autoscaling:DescribeTags",
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "ec2:DescribeLaunchTemplateVersions"
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes"
     ]
     resources = [
       "*",


### PR DESCRIPTION
## Problem
Current versions of the Cluster Autoscaler chart fail to deploy with an permission error.

## Cause
Since [Cluster Autoscaler version 1.23.0](https://github.com/kubernetes/autoscaler/releases/tag/cluster-autoscaler-1.23.0), the autoscaler requires an additional permission - ec2:DescribeInstanceTypes.
This PR fixes this, such that this module support cluster-autoscaler-chart >= 9.12.0

## Types of changes

What types of changes does your code introduce to <repo_name>?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the CONTRIBUTING.md doc.
- [x] I have added necessary documentation (if appropriate).
- [x] Any dependent changes have been merged and published in downstream modules.

## Further comments

It's probably also worth updating the default version for the helm chart, as 9.9.2 got released in March 2021.